### PR TITLE
Update footer.html | Add Direct link to the repository around the License text

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -54,7 +54,7 @@
     <div class="row">
     <!-- Copyright -->
     <div class="col-md-12 footer-copyright text-center py-3"> 
-        The Zeitgeist Movement is licensed under a Creative Commons Attribution-ShareAlike 4.0 International License
+        <a href="https://github.com/TZMCommunity/materials/blob/master/_includes/footer.html#L57">The Zeitgeist Movement is licensed under a Creative Commons Attribution-ShareAlike 4.0 International License</a>
     </div>
     <!-- Copyright -->
     </div>


### PR DESCRIPTION
The **#L57** of  
<code>https://github.com/TZMCommunity/materials/blob/master/_includes/footer.html<b>#L57</b></code>
Simply points to an exact line number where License text exist.

The line number might change in the future due to modification of the **footer.html**  

But it is great for now, even if the line number do change, the line number won't be far off.
